### PR TITLE
Fix link to fen-to-png in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All custom commands are stored in `quizbot/commands`.
 
 ## Credits
 This is built on top of Longman's great PHP telegram bot framework: https://github.com/php-telegram-bot/core<br/>
-I made a custom version of tikul's fen-to-png python script to generate images: https://github.com/tikul/fen-to-pn
+I made a custom version of tikul's fen-to-png python script to generate images: https://github.com/tikul/fen-to-png
 
 Special thanks to @mmlart, @igniperch, @MESSSERR, @Kon85 and @BomberHarris_XRP for helping input the chess problems.   
 


### PR DESCRIPTION
Github seems to have also automatically added some change to the newline-ing of the final line.